### PR TITLE
Make it work with "1,080" viruses

### DIFF
--- a/gisaid_scrapper.py
+++ b/gisaid_scrapper.py
@@ -108,7 +108,7 @@ class GisaidCoVScrapper:
         self.samples_count = int(
             self.driver.find_elements_by_xpath("//*[contains(text(), 'Total:')]")[
                 0
-            ].text.split(" ")[1]
+            ].text.split(" ")[1].replace(",", "")
         )
         self._update_cache()
 


### PR DESCRIPTION
Extra comma in "Total: 1,080 viruses" broke parsing of the number.
Also - thank you for this great scrapper.