### PR TITLE
Non-Windows Fix

### DIFF
--- a/gisaid_scrapper.py
+++ b/gisaid_scrapper.py
@@ -114,7 +114,7 @@ class GisaidCoVScrapper:
 
     def _update_cache(self):
         res = [
-            i.split("\\")[-1].split(".")[0]
+            i.split("/")[-1].split(".")[0]
             for i in glob.glob(f"{self.destination}/*.fasta")
         ]
         self.already_downloaded = res


### PR DESCRIPTION
I don't know much about python or Windows programming so this is mostly a suggestion that I hope you can use to make this script a multiplatform.
Changing backslash to slash fixes cache on MacOS which is critical to successfully download all the 1,080 viruses available at the time of writing.